### PR TITLE
Java 24 Updates

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,9 +4,9 @@ run-name: 'Build Workflow -- ${{ github.head_ref || github.ref_name }}'
 
 # Pipeline/Workflow Triggers
 on:
-    push:
-    pull_request:
-    workflow_dispatch:
+  push:
+  pull_request:
+  workflow_dispatch:
 
 
 jobs:
@@ -16,16 +16,13 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Pull Request Version Validation
-        uses: ikmdev/maven-pull-request-version-validation-action@v1.0.0
-        
+        uses: ikmdev/maven-pull-request-version-validation-action@v2.1.0
+
   build-job:
     name: Build Job
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
       - name: Build IKMDEV Code
-        uses: ikmdev/maven-clean-install-build-action@v3.2.0
+        uses: ikmdev/maven-clean-install-build-action@v3.5.0
         with:
           branch_name: ${{github.ref_name}}

--- a/.github/workflows/post_build.yaml
+++ b/.github/workflows/post_build.yaml
@@ -47,7 +47,7 @@ jobs:
           
       - name: IKMDEV Post Build Action
         id: ikmdev_post_build
-        uses: ikmdev/maven-post-build-action@v3.1.0
+        uses: ikmdev/maven-post-build-action@v3.2.0
         with:
             nexus_repo_password: ${{secrets.EC2_NEXUS_PASSWORD}}
             branch_name: ${{env.BRANCH_NAME}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: '23'
+          java-version: '24'
 
       - name: Maven Build Plugin
         shell: bash
@@ -59,7 +59,7 @@ jobs:
             -f tinkar-starter-data-maven-plugin
 
       - name: Shared Release Action
-        uses: ikmdev/maven-semver-release-action@v2.2.0
+        uses: ikmdev/maven-semver-release-action@v2.7.0
         with:
           version_type: ${{ github.event.inputs.version_type }}
           github_token: ${{secrets.GITHUB_TOKEN}}

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,12 @@
     </scm>
 
     <properties>
+        <!-- Properties Needed To Build On Java 24 (Start) -->
+        <java.version>24</java.version>
+        <maven-dependency-analyzer.version>1.16.0</maven-dependency-analyzer.version>
+        <maven-pmd-plugin.version>3.27.0</maven-pmd-plugin.version>
+        <!-- Properties Needed To Build On Java 24 (End) -->
+
         <!-- Tinkar dependencies -->
         <tinkar-core.version>1.112.0</tinkar-core.version>
         <tinkar-composer.version>1.8.0</tinkar-composer.version>
@@ -246,6 +252,42 @@
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>${builder-helper-maven-plugin.version}</version>
                 </plugin>
+
+                <!-- Maven Dependency Plugin Fix (Start) -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>analyze</id>
+                            <goals>
+                                <goal>analyze-only</goal>
+                            </goals>
+                            <configuration>
+                                <ignoredNonTestScopedDependencies>
+                                    <ignoredNonTestScopedDependency>org.slf4j:*</ignoredNonTestScopedDependency>
+                                </ignoredNonTestScopedDependencies>
+                                <ignoredUnusedDeclaredDependencies>
+                                    <ignoredUnusedDeclaredDependency>org.slf4j:*</ignoredUnusedDeclaredDependency>
+                                </ignoredUnusedDeclaredDependencies>
+                                <ignoreUnusedRuntime>true</ignoreUnusedRuntime>
+                                <ignoredUsedUndeclaredDependencies>
+                                    <ignoredUsedUndeclaredDependency>dev.ikm.jpms:eclipse-collections-api</ignoredUsedUndeclaredDependency>
+                                </ignoredUsedUndeclaredDependencies>
+                            </configuration>
+                        </execution>
+                    </executions>
+                    <dependencies>
+                        <!-- Necessary for JDK 24. Should be removed for updates of dependency plugin -->
+                        <dependency>
+                            <groupId>org.apache.maven.shared</groupId>
+                            <artifactId>maven-dependency-analyzer</artifactId>
+                            <version>${maven-dependency-analyzer.version}</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+                <!-- Maven Dependency Plugin Fix (End) -->
+
             </plugins>
         </pluginManagement>
     </build>
@@ -270,6 +312,28 @@
                 <deployRepositoryUrl>file:${project.build.directory}/local_deploy_repo/snapshot</deployRepositoryUrl>
             </properties>
         </profile>
+        <!-- codeQuality profile to override pmd configuration from build-parent
+         Need to ovverride aggregate parameter as it is deprecated. -->
+        <profile>
+            <!-- To disable this, use something like "mvn install -P!codeQuality" -->
+            <id>codeQuality</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-pmd-plugin</artifactId>
+                        <configuration>
+                            <aggregate combine.self="override"></aggregate> <!-- Overridden due to deprecation -->
+                            <targetJdk>${java.version}</targetJdk>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
     </profiles>
 </project>
 


### PR DESCRIPTION
- Updated the GH Actions to us newer released versions
    - build.yaml
        - ikmdev/maven-pull-request-version-validation-action@v2.1.0
        - ikmdev/maven-clean-install-build-action@v3.5.0
        - ikmdev/maven-post-build-action@v3.2.0
        - ikmdev/maven-semver-release-action@v2.7.0

- Updated the maven wrapper to 3.9.11

- Added some properties
        - <java.version>24</java.version>
        - <maven-dependency-analyzer.version>1.16.0</maven-dependency-analyzer.version>
        - <maven-pmd-plugin.version>3.27.0</maven-pmd-plugin.version>

- Added codeQuality profile to override maven-pmd-plugin (aggregate parameter is deprecated)

- Added transitive dependency fix for maven-dependency-plugin